### PR TITLE
Added a patch to alias xclip.

### DIFF
--- a/links
+++ b/links
@@ -1,9 +1,7 @@
 #!/bin/bash
 
-sysname=$(uname -s)
 
-if [ "$sysname" == "Linux" ]
-then
+if [[ $(uname -s) == "Linux" ]] ; then
     # pbcopy is a Mac OS/X command, but under Linux we use xclip
     function pbcopy {
         xclip -selection clipboard

--- a/links
+++ b/links
@@ -1,10 +1,13 @@
 #!/bin/bash
 
-if ! [[ -f /usr/bin/pbcopy ]] ; then
-	if ! which xclip > /dev/null ; then
-		sudo apt install xclip -y
-	fi
-	alias pbcopy='xclip -selection clipboard'
+sysname=$(uname -s)
+
+if [ "$sysname" == "Linux" ]
+then
+    # pbcopy is a Mac OS/X command, but under Linux we use xclip
+    function pbcopy {
+        xclip -selection clipboard
+    }
 fi
 
 


### PR DESCRIPTION
I changed the code to not assume we are on Ubuntu and have `apt` available. I find the `alias` command does not seem to work in a bash script, so creating a function makes it work seamlessly.

We just detect we are on Linux, and we are golden.